### PR TITLE
docs: update documentation for Storybook 9 package structure changes

### DIFF
--- a/.changeset/update-docs-storybook-9.md
+++ b/.changeset/update-docs-storybook-9.md
@@ -1,0 +1,11 @@
+---
+"@tzvipm.dev/storybook-solidjs": patch
+"@tzvipm.dev/storybook-solidjs-vite": patch
+---
+
+docs: Update documentation to reflect Storybook 9 package structure changes
+
+- Remove references to deprecated packages (@storybook/addon-essentials, @storybook/addon-interactions, @storybook/addon-actions)
+- Update imports from @storybook/test to storybook/test
+- Direct users to official Storybook 9 testing documentation
+- Note that essential addons are now built into Storybook core

--- a/.changeset/update-docs-storybook-9.md
+++ b/.changeset/update-docs-storybook-9.md
@@ -1,6 +1,6 @@
 ---
-"@tzvipm.dev/storybook-solidjs": patch
-"@tzvipm.dev/storybook-solidjs-vite": patch
+'@tzvipm.dev/storybook-solidjs': patch
+'@tzvipm.dev/storybook-solidjs-vite': patch
 ---
 
 docs: Update documentation to reflect Storybook 9 package structure changes

--- a/README.md
+++ b/README.md
@@ -1,13 +1,36 @@
-# Storybook SolidJS
+<div>
+  <h1 align="center">⚡ Storybook SolidJS</h1>
+  <strong>
+    A framework to allow using <a href="https://storybook.js.org/">Storybook</a> with <a href="https://www.solidjs.com/">SolidJS</a>
+  </strong>
+</div>
 
-This is a framework to allow using [Storybook](https://storybook.js.org/) with [SolidJS](https://www.solidjs.com/).
+<div align="center">
+  <a
+    alt="TzviPM Logo"
+    href="https://www.tzvipm.dev"
+  >
+    <img
+      width="200px"
+      src="https://www.tzvipm.dev/logo.svg"
+    />
+  </a>
+</div>
+
+<hr />
+
+<!-- prettier-ignore-start -->
+[![npm version][npm-badge-renderer]][npm-renderer]
+[![npm version][npm-badge-vite]][npm-vite]
+[![MIT License][license-badge]][license]
+<!-- prettier-ignore-end -->
 
 ## Features
 
 - [x] `JS` and `TS` integration with Storybook CLI
 - [x] Fine grained updates in storybook controls
-- [x] Compatible with `@storybook/addon-interactions`
-- [x] Compatible with `@storybook/test`
+- [x] Compatible with Storybook interactions
+- [x] Compatible with `storybook/test`
 - [x] Code snippets generation in docs view mode
 - [ ] Automatic story actions
 - [ ] Full props table with description in docs view mode
@@ -15,18 +38,154 @@ This is a framework to allow using [Storybook](https://storybook.js.org/) with [
 
 ## Notes about pending features ⏳
 
-- **Automatic story actions**: Feature under research. For now actions can be implemented manually by using the `@storybook/addon-actions` API.
+- **Automatic story actions**: Feature under research. For now actions can be implemented manually by using the `storybook/actions` API.
 
 - **Full props table with description in docs view mode**: Feature under research. For now, props are rendered partially in the docs view table with a blank description.
 
 - **`SolidJS` docs in the official Storybook website**: It's still pending to add documentation about Storybook stories definitions using SolidJS.
 
-## Setup
+## Why This Fork?
 
-In an existing Solid project, run `npx storybook@latest init` (Storybook 8+ is required)
+The official Storybook SolidJS renderer has critical bugs that were not addressed for over a month after the release of Storybook 9, despite submitted patches. This fork provides a stable, working alternative for SolidJS developers who need reliable Storybook integration.
 
-See the [Storybook Docs](https://storybook.js.org/docs?renderer=solid) for the best documentation on getting started with Storybook.
+**Note**: The `npx storybook@latest init` command will install the official (buggy) renderer. Use the manual installation below for a working setup.
+
+## Getting Started
+
+### Installation
+
+```bash
+# Install dependencies
+pnpm add -D @tzvipm.dev/storybook-solidjs @tzvipm.dev/storybook-solidjs-vite storybook
+
+# Initialize Storybook
+npx storybook@latest init --skip-install
+```
+
+### Configuration
+
+Create or update your `.storybook/main.js`:
+
+```js
+export default {
+  stories: ['../src/**/*.stories.@(js|jsx|ts|tsx|mdx)'],
+  framework: '@tzvipm.dev/storybook-solidjs-vite',
+  addons: [
+    // Essential addons are now built into Storybook core
+    // Add any additional addons you need here
+  ],
+};
+```
+
+### Writing Your First Story
+
+Create a story file (e.g., `Button.stories.tsx`):
+
+```tsx
+import type { Meta, StoryObj } from '@tzvipm.dev/storybook-solidjs';
+import { Button } from './Button';
+
+const meta = {
+  title: 'Example/Button',
+  component: Button,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    backgroundColor: { control: 'color' },
+  },
+} satisfies Meta<typeof Button>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+  args: {
+    primary: true,
+    label: 'Button',
+  },
+};
+
+export const Secondary: Story = {
+  args: {
+    label: 'Button',
+  },
+};
+```
+
+### Running Storybook
+
+```bash
+# Start development server
+pnpm storybook
+
+# Build static Storybook
+pnpm build-storybook
+```
+
+## Requirements
+
+- **Node.js**: 18.0.0 or later
+- **Storybook**: 9.0.0 or later
+- **SolidJS**: ~1.9.0
+- **Vite**: 4.0.0 or later (supports v4, v5, and v6)
+
+## TypeScript Support
+
+Full TypeScript support is included out of the box. The types for `Meta` and `StoryObj` are specifically designed for SolidJS components, providing excellent IDE support and type safety.
+
+## Testing
+
+For testing with Storybook, please refer to the [official Storybook 9 testing documentation](https://storybook.js.org/docs/writing-tests).
+
+The only differences when using SolidJS are:
+
+- Import `Meta` and `StoryObj` types from `@tzvipm.dev/storybook-solidjs`
+- Use the SolidJS-specific setup shown in the examples above
+
+All other testing features work exactly as documented in the official Storybook docs.
+
+## Advanced Configuration
+
+### Custom Vite Config
+
+Your existing `vite.config.ts` is automatically used. To customize Vite config specifically for Storybook:
+
+```js
+// .storybook/main.js
+export default {
+  framework: '@tzvipm.dev/storybook-solidjs-vite',
+  viteFinal: async (config) => {
+    // Customize the Vite config here
+    return config;
+  },
+};
+```
+
+### Fine-grained Reactivity
+
+SolidJS's fine-grained reactivity works perfectly with Storybook controls. When you change a control value, only the affected parts of your component re-render.
+
+## Troubleshooting
+
+### Common Issues
+
+1. **HMR not working**: Ensure you're using a supported version of Vite (4.x, 5.x, or 6.x)
+2. **Type errors**: Make sure you're importing types from `@tzvipm.dev/storybook-solidjs`
+3. **Build errors**: Check that all peer dependencies are installed
+
+For more help, please [open an issue](https://github.com/TzviPM/storybook-solidjs/issues) on our GitHub repository.
 
 ## License
 
-[MIT License](./LICENSE)
+MIT
+
+<!-- prettier-ignore-start -->
+[npm-badge-renderer]: https://img.shields.io/npm/v/@tzvipm.dev/storybook-solidjs.svg?style=flat-square
+[npm-renderer]: https://npmjs.org/package/@tzvipm.dev/storybook-solidjs
+[npm-badge-vite]: https://img.shields.io/npm/v/@tzvipm.dev/storybook-solidjs-vite.svg?style=flat-square
+[npm-vite]: https://npmjs.org/package/@tzvipm.dev/storybook-solidjs-vite
+[license-badge]: https://img.shields.io/badge/license-MIT%20License-blue.svg?style=flat-square
+[license]: https://github.com/TzviPM/storybook-solidjs/blob/main/LICENSE
+<!-- prettier-ignore-end -->

--- a/packages/frameworks/solid-vite/README.md
+++ b/packages/frameworks/solid-vite/README.md
@@ -1,3 +1,81 @@
-# Storybook for SolidJS
+<div>
+  <h1 align="center">⚡ @tzvipm.dev/storybook-solidjs-vite</h1>
+  <strong>
+    Storybook for SolidJS and Vite: Develop SolidJS components in isolation with Hot Reloading
+  </strong>
+</div>
 
-See the [Storybook Docs](https://storybook.js.org/docs?renderer=solid) for the best documentation on getting started with Storybook.
+```
+pnpm add -D @tzvipm.dev/storybook-solidjs-vite
+```
+
+<div align="center">
+  <a
+    alt="TzviPM Logo"
+    href="https://www.tzvipm.dev"
+  >
+    <img
+      width="200px"
+      src="https://www.tzvipm.dev/logo.svg"
+    />
+  </a>
+</div>
+
+<hr />
+
+<!-- prettier-ignore-start -->
+[![npm version][npm-badge]][npm]
+[![MIT License][license-badge]][license]
+<!-- prettier-ignore-end -->
+
+## What is this?
+
+This package provides the official framework integration between Storybook and Vite for SolidJS projects. It enables fast HMR, optimized builds, and seamless integration with Vite's ecosystem.
+
+## Getting Started
+
+Visit our [GitHub repository](https://github.com/TzviPM/storybook-solidjs) for comprehensive documentation and setup instructions.
+
+## Features
+
+- ⚡ **Lightning Fast** - Powered by Vite's blazing fast HMR
+- 🔧 **Zero Config** - Works out of the box with your Vite config
+- 📦 **Optimized Builds** - Production-ready bundle optimization
+- 🎯 **TypeScript Support** - First-class TS support with Vite
+- 🔌 **Plugin Ecosystem** - Compatible with Vite plugins
+
+## Requirements
+
+- Vite 4.0.0 or later (supports Vite 4, 5, and 6)
+- SolidJS ~1.9.0
+- Storybook 9.0.0 or later
+
+## Setup
+
+This framework is automatically installed when you run `storybook init` in a Vite-based SolidJS project.
+
+For manual installation:
+
+```bash
+pnpm add -D @tzvipm.dev/storybook-solidjs-vite @tzvipm.dev/storybook-solidjs
+```
+
+Then add it to your `.storybook/main.js`:
+
+```js
+export default {
+  framework: '@tzvipm.dev/storybook-solidjs-vite',
+  stories: ['../src/**/*.stories.@(js|jsx|ts|tsx|mdx)'],
+};
+```
+
+## License
+
+MIT
+
+<!-- prettier-ignore-start -->
+[npm-badge]: https://img.shields.io/npm/v/@tzvipm.dev/storybook-solidjs-vite.svg?style=flat-square
+[npm]: https://npmjs.org/package/@tzvipm.dev/storybook-solidjs-vite
+[license-badge]: https://img.shields.io/badge/license-MIT%20License-blue.svg?style=flat-square
+[license]: https://github.com/TzviPM/storybook-solidjs/blob/main/LICENSE
+<!-- prettier-ignore-end -->

--- a/packages/renderers/solid/README.md
+++ b/packages/renderers/solid/README.md
@@ -1,3 +1,79 @@
-# Storybook SolidJS Renderer
+<div>
+  <h1 align="center">⚡ @tzvipm.dev/storybook-solidjs</h1>
+  <strong>
+    Storybook SolidJS renderer for building UI components in isolation
+  </strong>
+</div>
 
-See the [Storybook Docs](https://storybook.js.org/docs?renderer=solid) for the best documentation on getting started with Storybook.
+```
+pnpm add -D @tzvipm.dev/storybook-solidjs
+```
+
+<div align="center">
+  <a
+    alt="TzviPM Logo"
+    href="https://www.tzvipm.dev"
+  >
+    <img
+      width="200px"
+      src="https://www.tzvipm.dev/logo.svg"
+    />
+  </a>
+</div>
+
+<hr />
+
+<!-- prettier-ignore-start -->
+[![npm version][npm-badge]][npm]
+[![MIT License][license-badge]][license]
+<!-- prettier-ignore-end -->
+
+## What is this?
+
+This package provides the SolidJS renderer for Storybook. It allows you to develop and test SolidJS components in isolation with Storybook's powerful development environment.
+
+## Getting Started
+
+Visit our [GitHub repository](https://github.com/TzviPM/storybook-solidjs) for comprehensive documentation and setup instructions.
+
+## Features
+
+- 🎯 **Type-safe** - Full TypeScript support
+- ⚡ **Fast Refresh** - Instant feedback with Vite HMR
+- 🎨 **Interactive Controls** - Fine-grained component props manipulation
+- 🧪 **Testing Support** - Works with `@storybook/test`
+- 📝 **Auto-generated Docs** - Component documentation from your code
+
+## Quick Example
+
+```tsx
+// Button.stories.tsx
+import type { Meta, StoryObj } from '@tzvipm.dev/storybook-solidjs';
+import { Button } from './Button';
+
+const meta = {
+  title: 'Example/Button',
+  component: Button,
+} satisfies Meta<typeof Button>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+  args: {
+    primary: true,
+    label: 'Button',
+  },
+};
+```
+
+## License
+
+MIT
+
+<!-- prettier-ignore-start -->
+[npm-badge]: https://img.shields.io/npm/v/@tzvipm.dev/storybook-solidjs.svg?style=flat-square
+[npm]: https://npmjs.org/package/@tzvipm.dev/storybook-solidjs
+[license-badge]: https://img.shields.io/badge/license-MIT%20License-blue.svg?style=flat-square
+[license]: https://github.com/TzviPM/storybook-solidjs/blob/main/LICENSE
+<!-- prettier-ignore-end -->


### PR DESCRIPTION
- Remove references to deprecated packages (@storybook/addon-essentials, @storybook/addon-interactions, @storybook/addon-actions)
- Update imports from @storybook/test to storybook/test
- Direct users to official Storybook 9 testing documentation
- Note that essential addons are now built into Storybook core